### PR TITLE
Support control codes in String Encoder + Downstream fix in StringToExpression

### DIFF
--- a/src/modules/StringToExpressions.lua
+++ b/src/modules/StringToExpressions.lua
@@ -22,6 +22,8 @@ local function obfuscate_string_literal(str, base1, base2)
         n = 10, -- ASCII code for \n
         r = 13, -- ASCII code for \r
         t = 9   -- ASCII code for \t
+        ["'"] = 39, -- ASCII code for \'
+        ['"'] = 34  -- ASCII code for \"
     }
 
     local obfuscated = {}
@@ -53,7 +55,11 @@ local function obfuscate_string_literal(str, base1, base2)
 end
 
 function stringtoexpressions.process(script_content, base1, base2)
+    -- replace inline escaped quotes so the pattern matches the entire line
+    script_content = script_content:gsub('\\"', '!@!'):gsub("\\'", "@!@")
+
     return script_content:gsub("(['\"])(.-)%1", function(_, str)
+        str = str:gsub('!@!', '\\"'):gsub('@!@', "\\'")
         return obfuscate_string_literal(str, base1, base2)
     end)
 end

--- a/src/modules/StringToExpressions.lua
+++ b/src/modules/StringToExpressions.lua
@@ -21,7 +21,7 @@ local function obfuscate_string_literal(str, base1, base2)
     local escape_chars = {
         n = 10, -- ASCII code for \n
         r = 13, -- ASCII code for \r
-        t = 9   -- ASCII code for \t
+        t = 9,   -- ASCII code for \t
         ["'"] = 39, -- ASCII code for \'
         ['"'] = 34  -- ASCII code for \"
     }


### PR DESCRIPTION
## Description

Provide a brief description of the changes in this pull request.
While testing on one of my LUA project i noticed i got invalid code generated by the obfuscator. When using the string_encoder. I Tracked this down to strings that had control code \n or colors, or escaped quotes inside other strings.


## Related Issues

No issues logged on this one, but this relates to PR #23, further testing with other modules.

## Changes Made

- Moved to better pattern when identifying string in the string_encoder
- Made the string_encoder not encode the control codes so they still apply when decoded.
- StringToExpression Support escaped quotes e.g. \" and \' and encode correctly.
- Have proposed a method to support \" and \' when finding strings, by replacing before the find and replacing afterward. This may need some discussion on the approach.

## Testing Done
Testing was completed with Just String Encoder enabled to get this correct then turning on the StringToExpressions

```
local colors = {
    reset = "\27[0m",
    green = "\27[32m",
    red = "\27[31m",
    white = "\27[37m",
    cyan = "\27[36m",
    blue = "\27[34m",
    yellow = "\27[33m"
}


local function Test()
    local test_string = colors.red .. "This\r\nis a \n\n\ntest\tstring"
    print(test_string)
end

Test()

local song_activate_name = "Test"

local macro = {
    "Set \"test quote\" %d",
    "Call \"" .. song_activate_name .."\"",
    'Testing "Mid string" of quotes',
    "Testing 'Mid string' of quotes",
}

print("Test", macro[1])
print("Test", macro[2])
print("Test", macro[3])
print("Test", macro[4])
print("Test", macro[5])
```

Explain what testing was performed, or steps to reproduce for reviewers.

## Checklist
- [ ] Code follows the project's coding guidelines.
- [ ] Relevant documentation has been updated (if needed).
- [ ] Tests have been added/updated (if applicable).
- [ ] All checks pass locally.

## Additional Notes

Include any extra information reviewers should know.
