### PR TITLE
Variable renamer fixes

### DIFF
--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -3,7 +3,7 @@ local varencNames = {}
 
 local lua_functions = {
     "assert", "collectgarbage", "dofile", "loadfile", "loadstring",
-    "pairs", "ipairs", "tonumber", "tostring", "type", "print",
+    "ipairs", "pairs", "tonumber", "tostring", "type", "print",
     "_G", "_VERSION", "write", "sort",
     "math.abs", "math.acos", "math.asin", "math.atan", "math.atan2",
     "math.ceil", "math.cos", "math.cosh", "math.deg", "math.exp",

--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -125,7 +125,7 @@ function VariableRenamer.process(code)
                 table.insert(renamed_vars, new_name)
                 table.insert(assignment_lines, new_name .. " = " .. function_name .. ";")
             end
-            replacements = string.gsub(replacements, function_name, varencNames[function_name])
+            replacements = replacements:gsub(function_name .. "%(", varencNames[function_name] .. "(")
         end
     end
 

--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -99,6 +99,9 @@ local function obfuscate_functions(code)
     -- update the function name
     for original_func, obfuscated_func in pairs(func_map) do
         obfuscated_code = obfuscated_code:gsub(original_func .. "%(", obfuscated_func .. "(")
+
+        -- support doing a return func;
+        obfuscated_code = obfuscated_code:gsub(original_func .. ";", obfuscated_func .. ";")
     end
 
     -- Update the function args

--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -34,8 +34,10 @@ local function replace_unquoted(input, target, replacement)
     local placeholder = "!!!"
 
     -- Replace target in quoted strings with a placeholder to skip them
-    local protected_input = input:gsub('(["\'])(.-)%1', function(quote, content)
-        return quote .. content:gsub(target, placeholder) .. quote
+    local protected_input = input:gsub('(["\'])(.-)%1', function(_, content)
+        content = content:gsub('\\"', '!@!'):gsub("\\'", "@!@")
+        content = content:gsub(target, placeholder)
+        content = content:gsub('!@!', '\\"'):gsub('@!@', "\\'")
     end)
 
     -- Replace standalone occurrences of the target outside of quotes
@@ -56,8 +58,10 @@ local function obfuscate_local_variables(code)
     -- update variable name
     for local_vars in code:gmatch(local_var_pattern) do
         for var in local_vars:gmatch("[%w_]+") do
-            if not var_map[var] then
-                var_map[var] = generate_random_name()
+            if #var > 1 then
+                if not var_map[var] then
+                    var_map[var] = generate_random_name()
+                end
             end
         end
     end

--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -68,7 +68,6 @@ local function obfuscate_local_variables(code)
 
     -- Update the variables args
     for original_var, obfuscated_var in pairs(var_map) do
-        print(original_var, obfuscated_var)
         obfuscated_code = replace_unquoted(obfuscated_code, original_var, obfuscated_var)
     end
 


### PR DESCRIPTION
## Description

Provide a brief description of the changes in this pull request.
Fixes based on testing of the renamer obfuscator

## Related Issues
Fixes #24 & #25 

## Changes Made

- ipairs and pairs were around the wrong way causing the replace of pairs to replace ipairs 
- the function renames were renaming variables of the same name, made functions rename to include func(
- split the renamer into two parts to enable easier testing. It might be a good idea to have them as a config option for the three features? @zeusssz 
- Implemented a new renamer function that only renames variables that are not inside 'replace not "replace"'
- support renaming on with return func;

## Testing Done

Explain what testing was performed, or steps to reproduce for reviewers.

Large number of test cases - this project prob needs to setup some sort of automated testing

```
local colors = {
    reset = "\27[0m",
    green = "\27[32m",
    red = "\27[31m",
    white = "\27[37m",
    cyan = "\27[36m",
    blue = "\27[34m",
    yellow = "\27[33m"
}


local function Test(message, message_second)
    local test_string = colors.red .. "This\r\nis a \n\n\ntest\tstring"
    print("message:", message, message_second)
end

function Test2(message)
    print("message:", message)
end

local song_activate_name = "Test"
local song_activate_name2 = "message"

Test(song_activate_name, song_activate_name2)
Test2(song_activate_name2)

local macro = {
    "Set \"test quote\" %d",
    "Call \"" .. song_activate_name .."\"",
    'Testing "Mid string" of quotes',
    "Testing 'Mid string' of quotes",
}

print("Test", macro[1])
print("Test", macro[2])
```

## Checklist

- [ ] Code follows the project's coding guidelines.
- [ ] Relevant documentation has been updated (if needed).
- [ ] Tests have been added/updated (if applicable).
- [ ] All checks pass locally.

## Additional Notes

Include any extra information reviewers should know.

## Known Issues
Overlapping Function Names will replace Config in OpenConfig if executed first messing up the OpenConfig function name
```
local function Config()
end
local function OpenConfig()
end
```
Workaround is to rename such functions to LoadConfig() and OpenConfig so they dont overlap.

Overlapping Variable & Arg names
There are downstream impacts of the gsub replacing across the entire file

```
local reset = "abc"
local colors = {
    reset = "\27[0m",
}

local example = "abc"
local function Test(example)
end

local example2 = {
    reset = "abc",    -- reset will be replaced
    example = "abc" -- reset will be replaced
}
MessageBox(example2) -- calling external function will be incorrect
```

Workaround rename args, and local vars to be unique.

