### PR TITLE
fix: escape percentage signs in restored strings

### DIFF
--- a/src/modules/compressor.lua
+++ b/src/modules/compressor.lua
@@ -14,7 +14,9 @@ end
 
 local function restorestrs(code, storedstrs)
     for placeholder, original in pairs(storedstrs) do
-        code = code:gsub(placeholder, original)
+        code = code:gsub(placeholder, function()
+            return original:gsub("%%", "%%%%")
+        end)
     end
     return code
 end

--- a/src/modules/compressor.lua
+++ b/src/modules/compressor.lua
@@ -5,7 +5,7 @@ local function preservestrs(code)
     local index = 0
     code = code:gsub("(['\"])(.-)%1", function(quote, content)
         index = index + 1
-        local placeholder = "___STRING_" .. index .. "___"
+        local placeholder = "@__STRING_" .. index .. "__@"
         storedstrs[placeholder] = quote .. content .. quote
         return placeholder
     end)
@@ -25,7 +25,7 @@ function Compressor.process(code)
     if type(code) ~= "string" then
         error("Input code must be a string.")
     end
-    if code:match("^[\\d\\%\\]+$") then
+    if code:match("^[%d%%%]+$") then
         return code
     end
     local lua_keywords = {

--- a/src/modules/variable_renamer.lua
+++ b/src/modules/variable_renamer.lua
@@ -49,7 +49,7 @@ local function replace_unquoted(input, target, replacement)
 end
 
 local function obfuscate_local_variables(code)
-    local local_var_pattern = "local%s+([%w_,%s]+)%s*=%s*"
+    local local_var_pattern = "local%s+([%w_,%s]+)%s*=?"
     local var_map = {}
     local obfuscated_code = code
 
@@ -127,7 +127,8 @@ function VariableRenamer.process(code)
         end
     end
     local local_declaration = #renamed_vars > 0 and "local " .. table.concat(renamed_vars, ", ") or ""
-    return local_declaration .. (#assignment_lines > 0 and "\n" .. table.concat(assignment_lines, " ") or "") .. "\n" .. obfuscated_code
+    return local_declaration ..
+        (#assignment_lines > 0 and "\n" .. table.concat(assignment_lines, " ") or "") .. "\n" .. obfuscated_code
 end
 
 return VariableRenamer


### PR DESCRIPTION
## Description

-Escape percentage signs in restored strings
-Update string placeholder format and regex for code validation


---

### Local Variable Identification
The pattern used for capturing local variables (`local_var_pattern`) works for simple cases but may fail in complex scenarios, such as:

```lua
local x, y = 1, function() return 2 end
local tbl = { key = value, nested = { inner = true } }
```

#### Improved Pattern
```lua
local local_var_pattern = "local%s+([%w_,%s]+)%s*=?"
```

## Checklist

- Code follows the project's coding guidelines. [Y]
- Relevant documentation has been updated (if needed). [N]
- Tests have been added/updated (if applicable). [N]
- All checks pass locally. [Y]